### PR TITLE
feat: added card styles to the animated drag card component

### DIFF
--- a/src/components/kanban-board.component.tsx
+++ b/src/components/kanban-board.component.tsx
@@ -480,7 +480,13 @@ class KanbanBoard extends React.Component<Props, State> {
       dragRotate: rotate,
       startingX,
       startingY } = this.state;
-    const { renderCardContent } = this.props;
+    const { 
+      renderCardContent,
+      cardContainerStyle,
+      cardTitleTextStyle,
+      cardSubtitleTextStyle,
+      cardContentTextStyle
+     } = this.props;
     if (!draggedItem || !movingMode) {
       return;
     }
@@ -507,6 +513,10 @@ class KanbanBoard extends React.Component<Props, State> {
           model={draggedItem!}
           hidden={false}
           renderCardContent={renderCardContent}
+          cardContainerStyle={cardContainerStyle}
+          cardTitleTextStyle={cardTitleTextStyle}
+          cardSubtitleTextStyle={cardSubtitleTextStyle}
+          cardContentTextStyle={cardContentTextStyle}
         />
       </Animated.View>
     );


### PR DESCRIPTION

This pull request allows the **DragCard component**(The Card component shown when the card is being dragged) to be styled alongside the "normal" **Card component**.

Image 1: Drag Card with no style
Image 2: Drag Card taking the card style

<div style="flex-direction:row">
<img src="https://github.com/Intechnity-com/react-native-kanban-board/assets/58832119/d24b9dec-3a63-46ec-98e4-241321b08df4" width="300" alt="Drag card with no style"/>
<img src="https://github.com/Intechnity-com/react-native-kanban-board/assets/58832119/30eedf61-bacc-4a1f-9f99-8f36a70a6287" width="300" alt="Drag card with no style"/>
</div>

<br>
<br>
<br>
Thank you for your excellent work @Intechnity-com
